### PR TITLE
Add `language-latex2e` to activation hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "main": "./lib/main",
   "version": "0.3.0",
   "description": "Autocomplete+ Support for Bibtex References in Latex",
-  "activationHooks": ["language-latex:grammar-used"],
+  "activationHooks": [
+    "language-latex:grammar-used",
+    "language-latex2e:grammar-used"
+  ],
   "keywords": [],
   "engines": {
     "atom": ">=1.0.0 <2.0.0"


### PR DESCRIPTION
For #4.

As I said there, this is the only way to do it with the tools provided by Atom (for now at least). It won't affect anything, aside from also activating if [`language-latex2e`](https://github.com/Aerijo/language-latex2e) is used.