### PR TITLE
[lib] skip ALIAS directive

### DIFF
--- a/lib/lite-bibtex-parse.js
+++ b/lib/lite-bibtex-parse.js
@@ -351,6 +351,8 @@ class BibtexParser {
         this.preamble()
       } else if (d.toUpperCase() === "@COMMENT") {
         this.comment()
+     } else if (d.toUpperCase() === "@ALIAS") {
+        this.comment()
       } else {
         this.entry(d)
       }


### PR DESCRIPTION
`bibtool` supports an `ALIAS` directive that enables key indirection. It was causing this package to barf when parsing `bib` files containing such entries.