### PR TITLE
adding option to exclude all Notes.bib files from search

### DIFF
--- a/lib/cite-manager.coffee
+++ b/lib/cite-manager.coffee
@@ -45,7 +45,7 @@ class CiteManager
     events = events.filter (e) -> /bib$/.test(e.path)
     # if exclude Notes.bib files, filter all *Notes.bib files out
     if atom.config.get('autocomplete-latex-cite.excludeNotesBibFiles')
-      events = events.filter (e) -> !/Notes\.bib/.test(e.path)
+      events = events.filter (e) -> !/Notes\.bib$/.test(e.path)
     # Filter multiple events for one file
     flags = {}
     events = events.reverse().filter (e) ->

--- a/lib/cite-manager.coffee
+++ b/lib/cite-manager.coffee
@@ -43,6 +43,9 @@ class CiteManager
   handleWatcherEvents: (events) =>
     # Filter for bib files
     events = events.filter (e) -> /bib$/.test(e.path)
+    # if exclude Notes.bib files, filter all *Notes.bib files out
+    if atom.config.get('autocomplete-latex-cite.excludeNotesBibFiles')
+      events = events.filter (e) -> !/Notes\.bib/.test(e.path)
     # Filter multiple events for one file
     flags = {}
     events = events.reverse().filter (e) ->
@@ -113,7 +116,10 @@ class CiteManager
 
   removeGlobalBibFiles: () ->
     if @globalPathWatcher
-      files = glob.sync(path.join(@globalPathWatcher.watchedPath, '**/*.bib'))
+      if atom.config.get('autocomplete-latex-cite.excludeNotesBibFiles')
+        files = glob.sync(path.join(@globalPathWatcher.watchedPath, '**/*.bib'), {"ignore":[path.join(folder, '**/*Notes.bib')]})
+      else
+        files = glob.sync(path.join(@globalPathWatcher.watchedPath, '**/*.bib'))
       for file in files
         @removeBibtexFile(file)
       @globalPathWatcher.dispose()
@@ -121,7 +127,10 @@ class CiteManager
       @globalPathWatcher = undefined
 
   addFilesFromFolder: (folder) ->
-    files = glob.sync(path.join(folder, '**/*.bib'))
+    if atom.config.get('autocomplete-latex-cite.excludeNotesBibFiles')
+      files = glob.sync(path.join(folder, '**/*.bib'), {"ignore":[path.join(folder, '**/*Notes.bib')]})
+    else
+      files = glob.sync(path.join(folder, '**/*.bib'))
     promises = []
     for file in files
       promises.push(@addBibtexFile(file))

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -33,3 +33,8 @@ module.exports =
     order: 1
     default: false
     description: 'Add the bibtex entries in the global files to the suggestions list.'
+  excludeNotesBibFiles:
+    type: 'boolean'
+    order: 3
+    default: false
+    description: 'Exlude the *Notes.bib files that are created during bibtex of main tex file'


### PR DESCRIPTION
At least on macOS, the bibtex step generates a `<your_paper>Notes.bib` file.  This bib file is not one that `autocomplete-latex-cite` knows how to parse, so every time one recompiles, it triggers lots of annoying warnings you have to close about an ill formatted `bib` file.  I added an option, defaulted to `false`, to exclude any `*Notes.bib` files from the `addFilesFromFolder`, `removeGlobalBibFiles` and `handleWatcherEvents` functions.  I have tested this new feature, with the option set to true and false and have eliminated all errors I could think of/find.  The optional feature shows up in the `Settings` of the `autocomplete-latex-cite` package underneath the options of adding global paths for bib files.